### PR TITLE
Added failing test for releasing numeric items

### DIFF
--- a/lib/gertrude/items/item_server.rb
+++ b/lib/gertrude/items/item_server.rb
@@ -30,7 +30,8 @@ class ItemServer < Sinatra::Base
   end
 
   get '/release/item' do
-    (!@items_list.release_item(params[:item])).to_json
+    item = params[:item]
+    (!@items_list.release_item(item)).to_json
   end
 
   get '/reserved' do

--- a/lib/gertrude/items/items_list.rb
+++ b/lib/gertrude/items/items_list.rb
@@ -30,6 +30,7 @@ class ItemsList
   end
 
   def release_item(item)
+    item = item.to_s
     raise ItemError::InvalidItem.new(item) unless @items.has_deep_key?(item)
     @items.deep_find(item)[RESERVE_KEY] = false
     @items.deep_find(item).delete(:reserved_time)

--- a/spec/items_list_spec.rb
+++ b/spec/items_list_spec.rb
@@ -82,7 +82,7 @@ describe 'items list' do
   describe '#get_all_items' do
     it 'should return a string of reserved items' do
       allow(item_list).to receive(:all_items).and_return(item_list.items)
-      response_hash = {"admin" => {"danny7" => {"danny7" => {"user_name" => "danny9", "rep_id" => "100014620", "profile_id" => "8190"}}, "johnny5" => {"johnny5" => {"user_name" => "danny7", "rep_id" => "100014624", "profile_id" => "8192"}}}}
+      response_hash = {"admin" => {"danny7" => {"danny7" => {"user_name" => "danny9", "rep_id" => "100014620", "profile_id" => "8190"}}, "johnny5" => {"johnny5" => {"user_name" => "danny7", "rep_id" => "100014624", "profile_id" => "8192"}}, "5015806226" => {"5015806226" => {'user_name' => '5015806226', 'rep_id' => '100014698', 'profile_id' => '8193'}}}}
       expect(item_list.get_all_items).to eql response_hash
     end
   end
@@ -121,7 +121,7 @@ describe 'items list' do
   describe '#available_items' do
     it 'should return an array of available items' do
       item_list.items['admin']['danny7'][ItemsList::RESERVE_KEY] = true
-      expect(item_list.available_items).to eql ['johnny5']
+      expect(item_list.available_items).to eql ['johnny5', '5015806226']
     end
   end
 

--- a/spec/items_list_spec.rb
+++ b/spec/items_list_spec.rb
@@ -5,9 +5,19 @@ describe 'items list' do
   let(:item) { {'danny7' => {'user_name' => 'danny9', 'rep_id' => '100014624', 'profile_id' => '8192'}} }
 
   before(:each) do
-    item_list.items = {'admin' =>
-                           {'danny7' => {'user_name' => 'danny9', 'rep_id' => '100014620', 'profile_id' => '8190', ItemsList::RESERVE_KEY.to_sym => false},
-                            'johnny5' => {'user_name' => 'danny7', 'rep_id' => '100014624', 'profile_id' => '8192', ItemsList::RESERVE_KEY.to_sym => false}}}
+    item_list.items = {
+      'admin' => {
+        'danny7' => {
+          'user_name' => 'danny9', 'rep_id' => '100014620', 'profile_id' => '8190', ItemsList::RESERVE_KEY.to_sym => false
+        },
+        'johnny5' => {
+          'user_name' => 'danny7', 'rep_id' => '100014624', 'profile_id' => '8192', ItemsList::RESERVE_KEY.to_sym => false
+        },
+        '5015806226' => {
+          'user_name' => '5015806226', 'rep_id' => '100014698', 'profile_id' => '8193', ItemsList::RESERVE_KEY.to_sym => false
+        }
+      }
+    }
   end
 
   describe '#unique_keys_across_items' do
@@ -46,6 +56,12 @@ describe 'items list' do
 
     it('should raise Invalid Item error when trying to release non reserved item') do
       expect { item_list.release_item('foo') }.to raise_error(ItemError::InvalidItem)
+    end
+
+    it('should release an item that is all numeric characters') do
+      item_list.items['admin']['5015806226'][ItemsList::RESERVE_KEY] = true
+      expect(item_list.release_item(5015806226)).to be nil
+      expect(item_list.items['admin']['5015806226'][ItemsList::RESERVE_KEY]).to be false
     end
   end
 
@@ -186,7 +202,7 @@ describe 'items list' do
       expect { ItemsList.new.load_items!('blah123') }.to raise_error(Errno::ENOENT)
     end
 
-    it 'should convert keys to strings' do
+    it 'should convert numeric keys to strings' do
       allow(YAML).to receive(:load_file).with('').and_return(numeric_hash)
       expect(ItemsList.new.load_items!('').items["numeric"].keys).to include(*["12345", "967979"])
     end


### PR DESCRIPTION
We already have tests for converting numeric items in the YML file to strings, but when a numeric value comes through from the url we need to convert it to a string before ruby converts it because it thinks its an octal number. 